### PR TITLE
Simplify Object.assign

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ export function connect (mapStateToProps) {
       render (props, state) {
         return h(
           WrappedComponent,
-          Object.assign({}, Object.assign({}, props), state, {
+          Object.assign({}, props, state, {
             emit: this.store.emit,
             actions: this.store.actions
           })


### PR DESCRIPTION
Original was multi-tiered & doing more work than was needed.